### PR TITLE
Fix combobox rendering using implicitWidth, implicitHeight

### DIFF
--- a/src/package/contents/ui/ComboBox.qml
+++ b/src/package/contents/ui/ComboBox.qml
@@ -164,6 +164,8 @@ RowLayout {
         }
 
         background: Rectangle {
+            implicitWidth: combobox.width
+            implicitHeight: combobox.height
             color: Qt.rgba(0, 0, 0, 0)
             border.color: theme.highlightColor
             border.width: combobox.down || combobox.customHovered ? 1 : 0


### PR DESCRIPTION
Combobox in the interface is not rendering in Plasma 5.27.5, defining implicitWidth, implicitHeight fixes